### PR TITLE
fix error when necessary options are missing

### DIFF
--- a/bin/nodeppt
+++ b/bin/nodeppt
@@ -18,7 +18,7 @@ program
     .action(function (filename, options) {
         if(typeof filename === 'object'){
             console.log('ERROR: please input filename！'.bold.red);
-            this.commands[0].outputHelp()
+            this.outputHelp();
             return;
         }
 
@@ -72,7 +72,7 @@ program
     .option('-H, --host [host]', 'set host address', ipv4 || '0.0.0.0')
     .action(function (cmd){
         if(typeof  cmd !== 'object'){
-            this.commands[2].outputHelp()
+            this.outputHelp();
             return;
         }
 
@@ -96,7 +96,7 @@ program
     .action(function (http_url, save_path) {
         if(typeof  http_url !== 'string' || typeof  save_path !== 'string'){
             console.log('ERROR: pdf need a URL'.bold.red);
-            this.commands[3].outputHelp()
+            this.outputHelp();
             return;
         }
 


### PR DESCRIPTION
When using `node create` without `[filename]` argument, it exits with an exception:

```
ERROR: please input filename！

/usr/local/lib/node_modules/nodeppt/bin/nodeppt:21
            this.commands[0].outputHelp()
                             ^
TypeError: Cannot call method 'outputHelp' of undefined
    at Command.program.command.usage.description.option.option.action.filename (/usr/local/lib/node_modules/nodeppt/bin/nodeppt:21:30)
    at Command.listener (/usr/local/lib/node_modules/nodeppt/node_modules/commander/index.js:287:8)
    at Command.emit (events.js:98:17)
    at Command.parseArgs (/usr/local/lib/node_modules/nodeppt/node_modules/commander/index.js:541:12)
    at Command.parse (/usr/local/lib/node_modules/nodeppt/node_modules/commander/index.js:427:21)
    at Object.<anonymous> (/usr/local/lib/node_modules/nodeppt/bin/nodeppt:117:9)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
```

This pull request can fix it up:)