### PR TITLE
解决加载特殊扩展名文件`Content-Type`为undefined报错问题

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -204,7 +204,7 @@ function assets(realPath, ext, url, res, argvObj) {
             } else {
                 res.writeHead(200, {
                     'Powered-By': 'nodePPT',
-                    'Content-Type': mimes[ext]
+                    'Content-Type': mimes[ext] || 'text/plain'
                 });
                 res.write(file, 'binary');
                 res.end();


### PR DESCRIPTION
加载`pen.cur`或`.woff`等文件时，扩展名不在mime.json中，会返回undefined导致在connect模块中调用`setHeader`方法时会报错。