### PR TITLE
mathjax 2.5.1 无法安装

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "read": ">=1.0.4",
     "socket.io": "1.3.3",
     "chokidar": "1.0.0-rc3",
-    "mathjax": "2.5.1"
+    "mathjax": "2.6.1"
   },
   "keywords": [
     "presentation",


### PR DESCRIPTION
npm ERR! shasum check failed for C:\Users\pc\AppData\Local\Temp\npm-10744-b2a85392\registry.npmjs.org\mathjax\-\mathjax-2.5.1.tgz
npm ERR! Expected: 7e9dde72faff8f7248e1d480a6971b4019a61890
npm ERR! Actual:   5f10fb0f11ece5ed28ca8eccc667aad7ccf429ea
npm ERR! From:     https://registry.npmjs.org/mathjax/-/mathjax-2.5.1.tgz
npm ERR!
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>
npm info preuninstall nodeppt@1.4.1
npm info uninstall nodeppt@1.4.1
npm info postuninstall nodeppt@1.4.1

npm ERR! Please include the following file with any support request:
npm ERR!     C:\Users\pc\Desktop\npm-debug.log