### PR TITLE
是否是目录-逻辑错误

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -92,14 +92,13 @@ $.isDir = function(dir, notwarning) {
             return false;
         }
 
-    } else {
-        var stat = fs.statSync(dir);
-        if (!stat.isDirectory()) {
-            if (!notwarning) {
-                console.log('ERROR: '.bold.red + dir + ' 不是一个正确路径');
-            }
-            return false;
+    }
+    var stat = fs.statSync(dir);
+    if (!stat.isDirectory()) {
+        if (!notwarning) {
+            console.log('ERROR: '.bold.red + dir + ' 不是一个正确路径');
         }
+        return false;
     }
     return true;
 }


### PR DESCRIPTION
path.join()之后，如果是个文件且文件存在，会直接返回true，然而它并不是一个目录。