### PR TITLE
fix mermaid class problem

### DIFF
--- a/packages/nodeppt-parser/lib/markdown/mermaid.js
+++ b/packages/nodeppt-parser/lib/markdown/mermaid.js
@@ -4,6 +4,7 @@ module.exports = md => {
         const token = tokens[idx];
         const code = token.content;
         if (token.info === 'mermaid') {
+            token.attrJoin('class', 'lang-mermaid no-style');
             let attrs = token.attrs || [];
             attrs = attrs
                 .map(([key, value]) => {
@@ -13,7 +14,7 @@ module.exports = md => {
             // 增加对 mermaidjs 支持，这样就可以画流程图了哦~
             return `
 <div class="embed">
-    <pre class="lang-mermaid no-style" ${attrs}>${code}</pre>
+    <pre ${attrs}>${code}</pre>
 </div>
 `;
         }


### PR DESCRIPTION
Mermaid的流程图没有办法添加class，例如以下代码无法正常出现动画：

````
title: nodeppt - test
speaker: Ciaran
url: https://github.com/ksky521/nodeppt
plugins:
    - mermaid

<slide>

### Demo

---

```mermaid {.tobuild.fadeInUp}
sequenceDiagram
    A ->> B: CCC
```
````

原因是pre中已经有了一个class属性，在原文件中添加的就没有效果了。