### PR TITLE
修正 file-loader 处理本地图片等静态文件时路径显示为 [object Module] 的问题

### DIFF
--- a/packages/nodeppt-parser/template/index.ejs
+++ b/packages/nodeppt-parser/template/index.ejs
@@ -7,11 +7,11 @@
 <head>
     <meta charset="UTF-8">
     <title><%= title %> - By <%= speaker %></title>
-    <link rel="stylesheet" href="//cdn.staticfile.org/font-awesome/4.7.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="//cdn.staticfile.org/prism/1.15.0/themes/prism.min.css">
-    <link rel="stylesheet" href="//cdn.staticfile.org/KaTeX/0.10.0-rc.1/katex.min.css">
+    <link rel="stylesheet" href="https://cdn.staticfile.org/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="https://cdn.staticfile.org/prism/1.15.0/themes/prism.min.css">
+    <link rel="stylesheet" href="https://cdn.staticfile.org/KaTeX/0.10.0-rc.1/katex.min.css">
     <% if (hasOwnProperty('prismTheme') && ['dark', 'coy', 'funky', 'okaidia', 'tomorrow', 'solarizedlight', 'twilight'].includes(prismTheme)) { %>
-        <link rel="stylesheet" href="//cdn.staticfile.org/prism/1.15.0/themes/prism-<%= prismTheme %>.min.css">
+        <link rel="stylesheet" href="https://cdn.staticfile.org/prism/1.15.0/themes/prism-<%= prismTheme %>.min.css">
     <% } %>
 
     <% if (hasOwnProperty('css') && css.length) { %>
@@ -21,7 +21,7 @@
     <% } %>
 
     <% if (hasOwnProperty('plugins') && plugins && plugins.indexOf && ~plugins.indexOf('katex')) { %>
-        <link rel="stylesheet" href="//cdn.staticfile.org/KaTeX/0.5.1/katex.min.css">
+        <link rel="stylesheet" href="https://cdn.staticfile.org/KaTeX/0.5.1/katex.min.css">
     <% } %>
 </head>
 <body>
@@ -31,10 +31,10 @@
     </article>
 </div>
 <% if (hasOwnProperty('plugins') && plugins && plugins.indexOf && ~plugins.indexOf('echarts')) { %>
-    <script src="//cdn.staticfile.org/echarts/4.1.0-release/echarts.min.js"></script>
+    <script src="https://cdn.staticfile.org/echarts/4.1.0-release/echarts.min.js"></script>
 <% } %>
 <% if (hasOwnProperty('plugins') && plugins && plugins.indexOf && ~plugins.indexOf('mermaid')) { %>
-    <script src="//cdn.staticfile.org/mermaid/8.0.0/mermaid.min.js"></script>
+    <script src="https://cdn.staticfile.org/mermaid/8.0.0/mermaid.min.js"></script>
     <script>mermaid.startOnLoad = false;</script>
 <% } %>
 

--- a/packages/nodeppt-serve/config/base.js
+++ b/packages/nodeppt-serve/config/base.js
@@ -21,7 +21,8 @@ module.exports = (api, options) => {
                 fallback: {
                     loader: 'file-loader',
                     options: {
-                        name: genAssetSubPath(dir)
+                        name: genAssetSubPath(dir),
+                        esModule: false
                     }
                 }
             };

--- a/packages/nodeppt/bin/nodeppt
+++ b/packages/nodeppt/bin/nodeppt
@@ -41,6 +41,7 @@ program
 program
     .command('build [entry]')
     .option('-m, --map', 'Release sourcemap')
+    .option('-d, --dest <dir>', 'output directory')
     .description('build html file')
     .action((entry, cmd) => {
         require('nodeppt-serve').build(entry, cleanArgs(cmd));
@@ -97,7 +98,7 @@ if (!program.args[0] && process.argv[2] !== 'new') {
 
 function cleanArgs(cmd) {
     const args = {version: packageJson.version};
-    cmd.options.forEach(o => {
+    cmd.options.forEach((o) => {
         const key = o.long.replace(/^--/, '');
         // if an option is not present and Command has a method with the same name
         // it should not be copied

--- a/site/echarts.md
+++ b/site/echarts.md
@@ -2,7 +2,7 @@ title: nodeppt 富媒体&插件演示
 speaker: 三水清
 url: https://github.com/ksky521/nodeppt
 js:
-    - https://www.echartsjs.com/asset/theme/infographic.js
+    - https://echarts.cdn.apache.org/zh/asset/theme/infographic.js
 plugins:
     - echarts: {theme: infographic}
 

--- a/site/index.md
+++ b/site/index.md
@@ -2,7 +2,7 @@ title: nodeppt - 这可能是迄今为止最好的网页版演示库
 speaker: 三水清
 url: https://github.com/ksky521/nodeppt
 js:
-    - https://www.echartsjs.com/asset/theme/infographic.js
+    - https://echarts.cdn.apache.org/zh/asset/theme/infographic.js
 plugins:
     - echarts: {theme: infographic}
     - mermaid: {theme: forest}


### PR DESCRIPTION
1. 修正 file-loader 处理本地图片等静态文件时路径显示为 [object Module] 的问题(#290)
2. 更正 echarts infographic 主题的 js 引用路径
3. build 命令支持 -d 参数，方便定义不同的输出路径
4. 模板文件统一使用 https 格式地址，以支持无 server 模式本地直接打开

